### PR TITLE
fixes bug that allowed repeated reminder adds within 5-min window

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,7 +276,10 @@ app.post('/sms', (req, res) => {
                 res.writeHead(200, { 'Content-Type': 'text/xml' });
                 res.end(twiml.toString());
             } else {
-                //phone exists in init_reminders, so insert the new Geomindr into the reminders table
+                //phone exists in init_reminders, so delete the entry from init_reminders
+                result.deleteInit();
+
+                // then, insert the new Geomindr into the reminders table
                 Location.createLocation(result.lat, result.lon)
                     .then(a => {
                         return { locationID: a };

--- a/models/Init_Reminder.js
+++ b/models/Init_Reminder.js
@@ -41,22 +41,7 @@ class Init_Reminder {
                 });
     }
 
-    // DELETE AFTER 5 MIN (working)
-    static deleteAfterNoResponse(id, callback) {
-        console.log('delete me!!');
-        setTimeout(
-            () =>
-                db
-                    .result(
-                        `delete from init_reminders
-                        where id = $1`,
-                        [id]
-                    )
-                    .then(callback),
-            300000
-        );
-    }
-
+    // === ===  RETRIEVE  === === (working)
     static getByPhone(phone_number) {
         return db
             .one('select * from init_reminders where phone = $1', [
@@ -76,6 +61,14 @@ class Init_Reminder {
                 return { id: 'not initiated' };
             });
     }
+
+    // === === DELETE === === (working)
+    deleteInit() {
+        //console.log('delete me!!');
+        db.result(`delete from init_reminders
+                    where phone = $1`,
+                    [this.phone]
+        )};
 }
 
 module.exports = Init_Reminder;


### PR DESCRIPTION
Adds instance method to the Init_Reminders class to allow an instance to delete the corresponding record from init_reminders table. Call this method just before inserting new record in the reminders table. If this isn't done, then a user can continue texting new reminders until 5 minutes has passed from when the IFTTT button was pushed.